### PR TITLE
fix(LocationEquipment): show locations filters after setting client filter on big screens

### DIFF
--- a/app/views/location_equipments/_filter_form.html.erb
+++ b/app/views/location_equipments/_filter_form.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag "location_equipment_filters" do %>
+<%= turbo_frame_tag "", class: "location_equipment_filters" do %>
   <%= form_with(url: url_for, method: :get, data: { turbo_stream: true }) do |f| %>
     <%= f.label :order, "Ordenar por", class: "form-label" %>
     <%= f.select :order,

--- a/app/views/location_equipments/index.turbo_stream.erb
+++ b/app/views/location_equipments/index.turbo_stream.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream.replace "location_equipments" do %>
   <%= render "shared/items", collection: @location_equipments %>
 <% end %>
-<%= turbo_stream.replace "location_equipment_filters",
+<%= turbo_stream.replace_all ".location_equipment_filters",
                         partial: "location_equipments/filter_form",
                         locals: { filter_params: @filter_params, order: @order } %>

--- a/spec/requests/location_equipments_spec.rb
+++ b/spec/requests/location_equipments_spec.rb
@@ -22,6 +22,23 @@ RSpec.describe "/location_equipments", type: :request do
         expect(response.body).to include(location_equipment.zone)
       end
     end
+
+    context "with filter params" do
+      it "filter by client" do
+        get location_equipments_url, params: {client_ids: [location_equipments.first.location.client_id]}
+        expect(response.body).to match("location_equipment_" + location_equipments.first.id.to_s)
+        expect(response.body).not_to match("location_equipment_" + location_equipments.last.id.to_s)
+      end
+
+      it "filter by client and location" do
+        location_equipments.last.location.client = location_equipments.first.client
+        location_equipments.last.save
+        params = {location_ids: [location_equipments.first.location_id], client_ids: [location_equipments.first.location.client_id]}
+        get location_equipments_url, params: params
+        expect(response.body).to match("location_equipment_" + location_equipments.first.id.to_s)
+        expect(response.body).not_to match("location_equipment_" + location_equipments.last.id.to_s)
+      end
+    end
   end
 
   describe "GET /show" do


### PR DESCRIPTION
Los filtros para salas no se mostraban luego de seleccionar un filtro para cliente