### PR TITLE
feat: add no data checkbox for oil pressure

### DIFF
--- a/app/javascript/controllers/report_input_controller.js
+++ b/app/javascript/controllers/report_input_controller.js
@@ -6,9 +6,9 @@ export default class extends Controller {
   connect() {
     this.checkboxTargets.forEach((checkbox) => {
       const formGroup = document.getElementById(checkbox.dataset.formGroupId);
-      const inputs = Array.from(formGroup.getElementsByTagName("input"));
+      const inputs = Array.from(formGroup.querySelectorAll("input, select"));
       inputs.forEach((input) => {
-        if (Math.round(input.value) === -1) {
+        if (input.value === "" || Math.round(input.value) === -1) {
           checkbox.checked = true;
           input.hidden = true;
         }
@@ -19,7 +19,7 @@ export default class extends Controller {
   toggleDisabled(event) {
     const checkbox = event.target;
     const formGroup = document.getElementById(checkbox.dataset.formGroupId);
-    const inputs = Array.from(formGroup.getElementsByTagName("input"));
+    const inputs = Array.from(formGroup.querySelectorAll("input, select"));
     inputs.forEach((input) => {
       if (checkbox.checked) {
         input.hidden = true;

--- a/app/models/power_unit_report_stat.rb
+++ b/app/models/power_unit_report_stat.rb
@@ -19,11 +19,15 @@ class PowerUnitReportStat < ApplicationRecord
     :tension_between_phases_c_a, :initial_temperature, :running_temperature, :number_of_starts, :operating_time, :failed_starts, :oil_pressure, :fuel_level,
     :coolant_level, :oil_level, :testing_time, :lamp_test, :belt_condition, :air_filter_condition, :anti_vibration_pad_condition, :liquids_leaks,
     :connections_condition_and_battery_fixation, :cable_and_electrical_connections, :general_disconnector,
-    :emergency_stop_position, :oil_pressure_unit, presence: true
+    :emergency_stop_position, presence: true
+  validates :oil_pressure_unit, presence: true, unless: :no_data_for_oil_pressure?
 
   validates :general_disconnector, inclusion: {in: GENERAL_DISCONNECTOR_OPTIONS}
   validates :emergency_stop_position, inclusion: {in: EMERGENCY_STOP_POSITION_OPTIONS}
   validates :start_key_on_auto, inclusion: {in: START_KEY_ON_AUTO_OPTIONS}
-  validates :oil_pressure_unit, inclusion: {in: OIL_PRESSURE_UNIT_OPTIONS}
   validates :coolant_level, inclusion: {in: COOLANT_LEVEL_OPTIONS}
+
+  def no_data_for_oil_pressure?
+    send(:oil_pressure).to_i.eql?(-1)
+  end
 end

--- a/app/services/reports/equipment/power_unit_stats.rb
+++ b/app/services/reports/equipment/power_unit_stats.rb
@@ -25,7 +25,7 @@ class Reports::Equipment::PowerUnitStats < Reports::Content
       [{content: "Número de arranques"}, {content: data_present?(power_unit_report_stat.number_of_starts)}, {content: "-"}],
       [{content: "Tiempo de funcionamiento (Hs)"}, {content: data_present?(power_unit_report_stat.operating_time)}, {content: "HS"}],
       [{content: "Arranques fallidos"}, {content: data_present?(power_unit_report_stat.failed_starts)}, {content: "-"}],
-      [{content: "Presión de aceite"}, {content: "#{power_unit_report_stat.oil_pressure} #{power_unit_report_stat.oil_pressure_unit}"}, {content: ">4 bar"}],
+      [{content: "Presión de aceite"}, {content: data_present?(power_unit_report_stat.oil_pressure, power_unit_report_stat.oil_pressure_unit)}, {content: ">4 bar"}],
       [{content: "Nivel de combustible"}, {content: data_present?(power_unit_report_stat.fuel_level)}, {content: ">3/4"}],
       [{content: "Nivel de refrigerante"}, {content: power_unit_report_stat.coolant_level.to_s}, {content: "Full"}],
       [{content: "Nivel de aceite"}, {content: power_unit_report_stat.oil_level.to_s}, {content: "Full"}],

--- a/app/views/reports/_power_unit_form.html.erb
+++ b/app/views/reports/_power_unit_form.html.erb
@@ -44,10 +44,17 @@
                                       attribute: :failed_starts,
                                       input_label: "Arranques fallidos",
                                       form_group_id: "failed_starts_form_group" %>
-    <div class="d-flex">
-      <%= power_unit_stats_form.input :oil_pressure, label: "Presión de aceite" %>
-      <%= power_unit_stats_form.input :oil_pressure_unit, label: "Unidad", collection: PowerUnitReportStat::OIL_PRESSURE_UNIT_OPTIONS %>
+    <div class="form-group">
+      <div class="d-flex" id="oil_pressure_form_group">
+        <%= power_unit_stats_form.input :oil_pressure, label: "Presión de aceite" %>
+        <%= power_unit_stats_form.input :oil_pressure_unit, label: "Unidad", collection: PowerUnitReportStat::OIL_PRESSURE_UNIT_OPTIONS %>
+      </div>
+      <div class="form-check mb-4">
+        <%= render "toggle_disable_checkbox", attribute: "oil_pressure", form_group_id: "oil_pressure_form_group", label: "Sin datos" %>
+      </div>
     </div>
+
+
     <%= render "no_data_check_input", form: power_unit_stats_form,
                                       attribute: :fuel_level,
                                       input_label: "Nivel de combustible",


### PR DESCRIPTION
[Prela-85](https://trello.com/c/OaTHHT2Z/85-85-agregar-casiila-sin-datos-a-presion-de-aceite-en-el-formulario-de-informes-de-grupos)