### PR TITLE
fix: use field_values to check if equipment is triphase

### DIFF
--- a/app/models/electrical_panel_report_stat.rb
+++ b/app/models/electrical_panel_report_stat.rb
@@ -39,7 +39,7 @@ class ElectricalPanelReportStat < ApplicationRecord
   validates :pat_splices_presence, inclusion: {in: [true, false]}
 
   def is_triphase?
-    report.location_equipment.equipment.is_triphase
+    report.location_equipment.equipment.is_triphase?
   end
 
   def is_monophase?

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -29,4 +29,8 @@ class Equipment < ApplicationRecord
   def kind
     legacy_kind
   end
+
+  def is_triphase?
+    ActiveModel::Type::Boolean.new.cast(field_values["is_triphase"])
+  end
 end

--- a/app/models/ups_report_stat.rb
+++ b/app/models/ups_report_stat.rb
@@ -19,6 +19,6 @@ class UpsReportStat < ApplicationRecord
   end
 
   def ups_triphase?
-    report.location_equipment.equipment.is_triphase
+    report.location_equipment.equipment.is_triphase?
   end
 end

--- a/app/views/reports/_legacy_form.html.erb
+++ b/app/views/reports/_legacy_form.html.erb
@@ -9,11 +9,11 @@
 
 <h2>Equipo</h2>
 <% if location_equipment.equipment.ups? %>
-  <%= render "ups_form", form: f, is_triphase: location_equipment.equipment.is_triphase %>
+  <%= render "ups_form", form: f, is_triphase: location_equipment.equipment.is_triphase? %>
 <% elsif location_equipment.equipment.power_unit? %>
   <%= render "power_unit_form", form: f %>
 <% elsif location_equipment.equipment.electrical_panel? %>
-  <%= render "electrical_panel_form", form: f, is_triphase: location_equipment.equipment.is_triphase %>
+  <%= render "electrical_panel_form", form: f, is_triphase: location_equipment.equipment.is_triphase? %>
 <% end %>
 
 <h2>Sala</h2>

--- a/spec/models/equipment_spec.rb
+++ b/spec/models/equipment_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe Equipment, type: :model do
     end
   end
 
+  describe "#is_triphase?" do
+    it "reads the Trifásica boolean from field_values" do
+      equipment = build(:equipment, field_values: {"is_triphase" => true})
+      expect(equipment.is_triphase?).to be true
+
+      equipment.field_values["is_triphase"] = "0"
+      expect(equipment.is_triphase?).to be false
+    end
+  end
+
   context "legacy_kind" do
     it "returns legacy_kind from equipment_kind" do
       equipment_kind = create(:equipment_kind, :ups)


### PR DESCRIPTION
[Prela-92](https://trello.com/c/9d84er5y/93-fix-ups-usar-fieldvaluetrifasico-en-vez-de-istriphase-para-el-formulario-clasico)